### PR TITLE
Moved `zendframework/zend-servicemanager` to the `require` section in `composer.json`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,16 @@
     "require": {
         "php": ">=5.5",
         "zendframework/zend-stdlib": "~2.5",
-        "zendframework/zend-validator": "~2.5"
+        "zendframework/zend-validator": "~2.5",
+        "zendframework/zend-servicemanager": "~2.5"
     },
     "require-dev": {
         "zendframework/zend-config": "~2.5",
-        "zendframework/zend-servicemanager": "~2.5",
         "zendframework/zendpdf": "*",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },
     "suggest": {
-        "zendframework/zend-servicemanager": "Zend\\ServiceManager component, required when using the factory methods of Zend\\Barcode.",
         "zendframework/zendpdf": "ZendPdf component"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Moved `zendframework/zend-servicemanager` to the `require` section in `composer.json`. Should fix error "Class 'Zend\ServiceManager\AbstractPluginManager' not found in .../vendor/zendframework/zend-barcode/src/ObjectPluginManager.php" when using `Zend\Barcode\Barcode::render()`.

Probably fixes #4 
