### PR TITLE
ServiceManager v2 + v3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,23 @@ matrix:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+    - php: 5.5
+      env:
+        - SERVICE_MANAGER_V2=true
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+    - php: 5.6
+      env:
+        - SERVICE_MANAGER_V2=true
     - php: 7
+    - php: 7
+      env:
+        - SERVICE_MANAGER_V2=true
     - php: hhvm 
+    - php: hhvm 
+      env:
+        - SERVICE_MANAGER_V2=true
   allow_failures:
     - php: 7
     - php: hhvm
@@ -38,6 +50,8 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $SERVICE_MANAGER_V2 == 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^2.7.2" ; fi
+  - if [[ $SERVICE_MANAGER_V2 != 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,23 +23,22 @@ matrix:
         - EXECUTE_CS_CHECK=true
     - php: 5.5
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
     - php: 5.6
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: 7
     - php: 7
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: hhvm 
     - php: hhvm 
       env:
-        - SERVICE_MANAGER_V2=true
+        - SERVICE_MANAGER_VERSION="^2.7.5"
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:
@@ -50,8 +49,8 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
-  - if [[ $SERVICE_MANAGER_V2 == 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^2.7.2" ; fi
-  - if [[ $SERVICE_MANAGER_V2 != 'true' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-stdlib": "~2.7",
-        "zendframework/zend-validator": "~2.5",
-        "zendframework/zend-servicemanager": "^2.7.2 || ^3.0"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0",
+        "zendframework/zend-validator": "^2.6",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
     },
     "require-dev": {
-        "zendframework/zend-config": "~2.5",
+        "zendframework/zend-config": "^2.6",
         "zendframework/zendpdf": "*",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
@@ -27,8 +27,6 @@
     "suggest": {
         "zendframework/zendpdf": "ZendPdf component"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "extra": {
         "branch-alias": {
             "dev-master": "2.5-dev",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.5",
         "zendframework/zend-stdlib": "~2.7",
         "zendframework/zend-validator": "~2.5",
-        "zendframework/zend-servicemanager": "dev-develop as 2.7.0"
+        "zendframework/zend-servicemanager": "^2.7.2 || ^3.0"
     },
     "require-dev": {
         "zendframework/zend-config": "~2.5",

--- a/src/ObjectPluginManager.php
+++ b/src/ObjectPluginManager.php
@@ -76,7 +76,28 @@ class ObjectPluginManager extends AbstractPluginManager
         Object\Postnet::class           => InvokableFactory::class,
         Object\Royalmail::class         => InvokableFactory::class,
         Object\Upca::class              => InvokableFactory::class,
-        Object\Upce::class              => InvokableFactory::class
+        Object\Upce::class              => InvokableFactory::class,
+
+        // v2 canonical FQCNs
+
+        'zendbarcodeobjectcodabar'           => InvokableFactory::class,
+        'zendbarcodeobjectcode128'           => InvokableFactory::class,
+        'zendbarcodeobjectcode25'            => InvokableFactory::class,
+        'zendbarcodeobjectcode25interleaved' => InvokableFactory::class,
+        'zendbarcodeobjectcode39'            => InvokableFactory::class,
+        'zendbarcodeobjectean13'             => InvokableFactory::class,
+        'zendbarcodeobjectean2'              => InvokableFactory::class,
+        'zendbarcodeobjectean5'              => InvokableFactory::class,
+        'zendbarcodeobjectean8'              => InvokableFactory::class,
+        'zendbarcodeobjecterror'             => InvokableFactory::class,
+        'zendbarcodeobjectidentcode'         => InvokableFactory::class,
+        'zendbarcodeobjectitf14'             => InvokableFactory::class,
+        'zendbarcodeobjectleitcode'          => InvokableFactory::class,
+        'zendbarcodeobjectplanet'            => InvokableFactory::class,
+        'zendbarcodeobjectpostnet'           => InvokableFactory::class,
+        'zendbarcodeobjectroyalmail'         => InvokableFactory::class,
+        'zendbarcodeobjectupca'              => InvokableFactory::class,
+        'zendbarcodeobjectupce'              => InvokableFactory::class,
     ];
 
     protected $instanceOf = Object\AbstractObject::class;
@@ -86,17 +107,17 @@ class ObjectPluginManager extends AbstractPluginManager
      *
      * Validates against `$instanceOf`.
      *
-     * @param mixed $instance
+     * @param mixed $plugin
      * @throws InvalidServiceException
      */
-    public function validate($instance)
+    public function validate($plugin)
     {
-        if (! $instance instanceof $this->instanceOf) {
+        if (! $plugin instanceof $this->instanceOf) {
             throw new InvalidServiceException(sprintf(
                 '%s can only create instances of %s; %s is invalid',
                 get_class($this),
                 $this->instanceOf,
-                (is_object($instance) ? get_class($instance) : gettype($instance))
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin))
             ));
         }
     }
@@ -106,11 +127,19 @@ class ObjectPluginManager extends AbstractPluginManager
      *
      * Proxies to `validate()`.
      *
-     * @param mixed $instance
-     * @throws InvalidServiceException
+     * @param mixed $plugin
+     * @throws Exception\InvalidArgumentException
      */
-    public function validatePlugin($instance)
+    public function validatePlugin($plugin)
     {
-        $this->validate($instance);
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Plugin of type %s is invalid; must extend %s',
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+                Object\AbstractObject::class
+            ), $e->getCode(), $e);
+        }
     }
 }

--- a/src/ObjectPluginManager.php
+++ b/src/ObjectPluginManager.php
@@ -10,6 +10,7 @@
 namespace Zend\Barcode;
 
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\Factory\InvokableFactory;
 
 /**
@@ -22,7 +23,12 @@ use Zend\ServiceManager\Factory\InvokableFactory;
 class ObjectPluginManager extends AbstractPluginManager
 {
     /**
-     * @var bool Ensure services are not shared
+     * @var bool Ensure services are not shared (v2 property)
+     */
+    protected $shareByDefault = false;
+
+    /**
+     * @var bool Ensure services are not shared (v3 property)
      */
     protected $sharedByDefault = false;
 
@@ -74,4 +80,37 @@ class ObjectPluginManager extends AbstractPluginManager
     ];
 
     protected $instanceOf = Object\AbstractObject::class;
+
+    /**
+     * Validate the plugin is of the expected type (v3).
+     *
+     * Validates against `$instanceOf`.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validate($instance)
+    {
+        if (! $instance instanceof $this->instanceOf) {
+            throw new InvalidServiceException(sprintf(
+                '%s can only create instances of %s; %s is invalid',
+                get_class($this),
+                $this->instanceOf,
+                (is_object($instance) ? get_class($instance) : gettype($instance))
+            ));
+        }
+    }
+
+    /**
+     * Validate the plugin is of the expected type (v2).
+     *
+     * Proxies to `validate()`.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validatePlugin($instance)
+    {
+        $this->validate($instance);
+    }
 }

--- a/src/RendererPluginManager.php
+++ b/src/RendererPluginManager.php
@@ -47,6 +47,12 @@ class RendererPluginManager extends AbstractPluginManager
         Renderer\Image::class => InvokableFactory::class,
         Renderer\Pdf::class   => InvokableFactory::class,
         Renderer\Svg::class   => InvokableFactory::class,
+
+        // v2 canonical FQCNs
+
+        'zendbarcoderendererimage' => InvokableFactory::class,
+        'zendbarcoderendererpdf'   => InvokableFactory::class,
+        'zendbarcoderenderersvg'   => InvokableFactory::class,
     ];
 
     protected $instanceOf = Renderer\AbstractRenderer::class;
@@ -56,17 +62,17 @@ class RendererPluginManager extends AbstractPluginManager
      *
      * Validates against `$instanceOf`.
      *
-     * @param mixed $instance
+     * @param mixed $plugin
      * @throws InvalidServiceException
      */
-    public function validate($instance)
+    public function validate($plugin)
     {
-        if (! $instance instanceof $this->instanceOf) {
+        if (! $plugin instanceof $this->instanceOf) {
             throw new InvalidServiceException(sprintf(
                 '%s can only create instances of %s; %s is invalid',
                 get_class($this),
                 $this->instanceOf,
-                (is_object($instance) ? get_class($instance) : gettype($instance))
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin))
             ));
         }
     }
@@ -76,11 +82,19 @@ class RendererPluginManager extends AbstractPluginManager
      *
      * Proxies to `validate()`.
      *
-     * @param mixed $instance
-     * @throws InvalidServiceException
+     * @param mixed $plugin
+     * @throws Exception\InvalidArgumentException
      */
-    public function validatePlugin($instance)
+    public function validatePlugin($plugin)
     {
-        $this->validate($instance);
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Plugin of type %s is invalid; must extend %s',
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+                Renderer\AbstractRenderer::class
+            ), $e->getCode(), $e);
+        }
     }
 }

--- a/src/RendererPluginManager.php
+++ b/src/RendererPluginManager.php
@@ -10,6 +10,7 @@
 namespace Zend\Barcode;
 
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\Factory\InvokableFactory;
 
 /**
@@ -22,7 +23,12 @@ use Zend\ServiceManager\Factory\InvokableFactory;
 class RendererPluginManager extends AbstractPluginManager
 {
     /**
-     * @var bool Ensure services are not shared
+     * @var bool Ensure services are not shared (v2)
+     */
+    protected $shareByDefault = false;
+
+    /**
+     * @var bool Ensure services are not shared (v3)
      */
     protected $sharedByDefault = false;
 
@@ -44,4 +50,37 @@ class RendererPluginManager extends AbstractPluginManager
     ];
 
     protected $instanceOf = Renderer\AbstractRenderer::class;
+
+    /**
+     * Validate the plugin is of the expected type (v3).
+     *
+     * Validates against `$instanceOf`.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validate($instance)
+    {
+        if (! $instance instanceof $this->instanceOf) {
+            throw new InvalidServiceException(sprintf(
+                '%s can only create instances of %s; %s is invalid',
+                get_class($this),
+                $this->instanceOf,
+                (is_object($instance) ? get_class($instance) : gettype($instance))
+            ));
+        }
+    }
+
+    /**
+     * Validate the plugin is of the expected type (v2).
+     *
+     * Proxies to `validate()`.
+     *
+     * @param mixed $instance
+     * @throws InvalidServiceException
+     */
+    public function validatePlugin($instance)
+    {
+        $this->validate($instance);
+    }
 }

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -11,9 +11,11 @@ namespace ZendTest\Barcode;
 
 use ReflectionClass;
 use Zend\Barcode;
+use Zend\Barcode\Exception\InvalidArgumentException;
 use Zend\Barcode\Renderer;
 use Zend\Barcode\Object;
 use Zend\Config\Config;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 use ZendPdf as Pdf;
 
 /**
@@ -237,8 +239,16 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $plugins = Barcode\Barcode::getObjectPluginManager();
         $plugins->setInvokableClass('barcodeNamespaceWithoutExtendingObjectAbstract', 'ZendTest\Barcode\Object\TestAsset\BarcodeNamespaceWithoutExtendingObjectAbstract');
 
-        $this->setExpectedException('Zend\ServiceManager\Exception\InvalidServiceException');
-        $barcode = Barcode\Barcode::makeBarcode('barcodeNamespaceWithoutExtendingObjectAbstract');
+        try {
+            Barcode\Barcode::makeBarcode('barcodeNamespaceWithoutExtendingObjectAbstract');
+            $this->fail('Invalid barcode object should raise an exception');
+        } catch (InvalidServiceException $e) {
+            // V3 exception
+            $this->assertInstanceOf(InvalidServiceException::class, $e);
+        } catch (InvalidArgumentException $e) {
+            // V2 exception
+            $this->assertInstanceOf(InvalidArgumentException::class, $e);
+        }
     }
 
     public function testBarcodeObjectFactoryWithUnexistentBarcode()
@@ -319,8 +329,17 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         $plugins = Barcode\Barcode::getRendererPluginManager();
         $plugins->setInvokableClass('rendererNamespaceWithoutExtendingRendererAbstract', 'ZendTest\Barcode\Renderer\TestAsset\RendererNamespaceWithoutExtendingRendererAbstract');
-        $this->setExpectedException('Zend\ServiceManager\Exception\InvalidServiceException');
-        $renderer = Barcode\Barcode::makeRenderer('rendererNamespaceWithoutExtendingRendererAbstract');
+
+        try {
+            Barcode\Barcode::makeRenderer('rendererNamespaceWithoutExtendingRendererAbstract');
+            $this->fail('Invalid barcode renderer should raise an exception');
+        } catch (InvalidServiceException $e) {
+            // V3 exception
+            $this->assertInstanceOf(InvalidServiceException::class, $e);
+        } catch (InvalidArgumentException $e) {
+            // V2 exception
+            $this->assertInstanceOf(InvalidArgumentException::class, $e);
+        }
     }
 
     public function testBarcodeRendererFactoryWithUnexistentRenderer()

--- a/test/ObjectPluginManagerCompatibilityTest.php
+++ b/test/ObjectPluginManagerCompatibilityTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-barcode for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Barcode;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Barcode\Exception\InvalidArgumentException;
+use Zend\Barcode\Object\AbstractObject;
+use Zend\Barcode\ObjectPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class ObjectPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new ObjectPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidArgumentException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return AbstractObject::class;
+    }
+}

--- a/test/RendererPluginManagerCompatibilityTest.php
+++ b/test/RendererPluginManagerCompatibilityTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-barcode for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Barcode;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Barcode\Exception\InvalidArgumentException;
+use Zend\Barcode\Renderer\AbstractRenderer;
+use Zend\Barcode\RendererPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class RendererPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new RendererPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidArgumentException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return AbstractRenderer::class;
+    }
+}


### PR DESCRIPTION
This patch updates the component to work with both v2 and v3 of zend-servicemanager. Specifically:
- Updates the dependency to `^2.7.2 || ^3.0` (2.7.2 is the first version that contains all features that allow plugin managers to work correctly across both versions)
- Updates the two plugin manager implementations to:
  - Add `$shareByDefault`, with a value equivalent to `$sharedByDefault` (former is v2, latter is v3).
  - Implement both `validate()` and `validatePlugin()`, with the latter proxying to the former.

Tests currently pass with either v2 or v3; ~~I'm currently working on travis configuration to allow testing against both~~; I've updated the travis matrix to run additional tests for each PHP version, with the default being against v3.0.3, and the alternate against v2.7.5+.

~~Marked as WIP, as it has a hard-dependency on zend-validator, and thus cannot be completed until a stable version of that component with forwards-compatibility is ready.~~
