### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     - secure: "OcQVNRTNC4jq+z7P2IvpUNB8RBA00wnlQb2NV5cq4yWqHOOS6yFdRttzklJocPJ8U6rrMFRgTSdnEXtJU4kpL1esR7Q5zS28bwogG1sCRGl0FYjmH6bc28pi5ayktiE/s8ycO6Bqg7qcX/uQDy2SbEIiWPk2Pg8YuKHu59lpQbqKHI45qfqALr0LcL6JdY5ktqX8ZuIe1S4Ovmylzir8T3FCKGFMFP86G580/aOhzxoMSlWVsWMhAh9RUVgPCmXxvwWh2s62GU2mPS9HJA6XcESp05pRQbjoifmvcnbrFx+AOMqmAhvlcrnozlwyKCbTLpTgpgDsjltNsEBYfolThHGNbTyZ9LpMGXVgTziVTbr+UqxjwXpBVPjbkpv4f1I3WwjqtJBOs1HIlNEgppug/Zyc6NfvCFL/ayXmQkdDSN7VpiFt88T9cIxw/2rmvSKi/qOtZv9Fhssucg2yufB9xLSWiGQt5+8aMbDUcBfwAuxoCg5C0YO05DQTWkb+ZAj7NOp7gGPWGJwWxY6lT+DKHVx7RcejcOczvxNPmnTPsCGE2EepTzZ+NwPubcoRWjx3DHe/vlU9dOSNGyUiW9ttocUj6eEiZTB2P9IsJ19gT+8dJ88gcSdRiaxNV+2LX+MBe3L4j5YzHzDH4reyPK1NR4m9Lmv1GCoQ04qozaCo0/U="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.5
       env:


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.
