### PR TITLE
Feature/docblock method chaining consistency

### DIFF
--- a/src/Object/AbstractObject.php
+++ b/src/Object/AbstractObject.php
@@ -255,7 +255,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set barcode state from options array
      *
      * @param  array $options
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      */
     public function setOptions($options)
     {
@@ -272,7 +272,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set barcode namespace for autoloading
      *
      * @param string $namespace
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      */
     public function setBarcodeNamespace($namespace)
     {
@@ -304,7 +304,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set height of the barcode bar
      *
      * @param int $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarHeight($value)
@@ -332,7 +332,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set thickness of thin bar
      *
      * @param int $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarThinWidth($value)
@@ -360,7 +360,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set thickness of thick bar
      *
      * @param int $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarThickWidth($value)
@@ -389,7 +389,7 @@ abstract class AbstractObject implements ObjectInterface
      * thinBarWidth - thickBarWidth - barHeight - fontSize
      *
      * @param int|float|string|bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFactor($value)
@@ -418,7 +418,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set color of the barcode and text
      *
      * @param string $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setForeColor($value)
@@ -449,7 +449,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set the color of the background
      *
      * @param int $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBackgroundColor($value)
@@ -480,7 +480,7 @@ abstract class AbstractObject implements ObjectInterface
      * Activate/deactivate drawing of the bar
      *
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      */
     public function setWithBorder($value)
     {
@@ -502,7 +502,7 @@ abstract class AbstractObject implements ObjectInterface
      * Activate/deactivate drawing of the quiet zones
      *
      * @param  bool $value
-     * @return AbstractObject
+     * @return AbstractObject Provides a fluent interface
      */
     public function setWithQuietZones($value)
     {
@@ -523,7 +523,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Allow fast inversion of font/bars color and background color
      *
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      */
     public function setReverseColor()
     {
@@ -537,7 +537,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set orientation of barcode and text
      *
      * @param int|float|string|bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setOrientation($value)
@@ -560,7 +560,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set text to encode
      *
      * @param string $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      */
     public function setText($value)
     {
@@ -635,7 +635,7 @@ abstract class AbstractObject implements ObjectInterface
      * Activate/deactivate drawing of text to encode
      *
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      */
     public function setDrawText($value)
     {
@@ -658,7 +658,7 @@ abstract class AbstractObject implements ObjectInterface
      * of the characters to the position of the bars
      *
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setStretchText($value)
@@ -684,7 +684,7 @@ abstract class AbstractObject implements ObjectInterface
      * added to the barcode text
      *
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      */
     public function setWithChecksum($value)
     {
@@ -711,7 +711,7 @@ abstract class AbstractObject implements ObjectInterface
      * added to the barcode text
      *
      * @param  bool $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setWithChecksumInText($value)
@@ -739,7 +739,7 @@ abstract class AbstractObject implements ObjectInterface
      *  - if string, $value is assumed to be the path to a TTF font
      *
      * @param int|string $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFont($value)
@@ -781,7 +781,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set the size of the font in case of TTF
      *
      * @param float $value
-     * @return \Zend\Barcode\Object\ObjectInterface
+     * @return AbstractObject Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFontSize($value)

--- a/src/Object/AbstractObject.php
+++ b/src/Object/AbstractObject.php
@@ -255,7 +255,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set barcode state from options array
      *
      * @param  array $options
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setOptions($options)
     {
@@ -272,7 +272,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set barcode namespace for autoloading
      *
      * @param string $namespace
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setBarcodeNamespace($namespace)
     {
@@ -304,7 +304,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set height of the barcode bar
      *
      * @param int $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarHeight($value)
@@ -332,7 +332,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set thickness of thin bar
      *
      * @param int $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarThinWidth($value)
@@ -360,7 +360,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set thickness of thick bar
      *
      * @param int $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBarThickWidth($value)
@@ -389,7 +389,7 @@ abstract class AbstractObject implements ObjectInterface
      * thinBarWidth - thickBarWidth - barHeight - fontSize
      *
      * @param int|float|string|bool $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFactor($value)
@@ -418,7 +418,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set color of the barcode and text
      *
      * @param string $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setForeColor($value)
@@ -449,7 +449,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set the color of the background
      *
      * @param int $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setBackgroundColor($value)
@@ -480,7 +480,7 @@ abstract class AbstractObject implements ObjectInterface
      * Activate/deactivate drawing of the bar
      *
      * @param  bool $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setWithBorder($value)
     {
@@ -502,7 +502,7 @@ abstract class AbstractObject implements ObjectInterface
      * Activate/deactivate drawing of the quiet zones
      *
      * @param  bool $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setWithQuietZones($value)
     {
@@ -523,7 +523,7 @@ abstract class AbstractObject implements ObjectInterface
     /**
      * Allow fast inversion of font/bars color and background color
      *
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setReverseColor()
     {
@@ -537,7 +537,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set orientation of barcode and text
      *
      * @param int|float|string|bool $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setOrientation($value)
@@ -560,7 +560,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set text to encode
      *
      * @param string $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setText($value)
     {
@@ -635,7 +635,7 @@ abstract class AbstractObject implements ObjectInterface
      * Activate/deactivate drawing of text to encode
      *
      * @param  bool $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setDrawText($value)
     {
@@ -658,7 +658,7 @@ abstract class AbstractObject implements ObjectInterface
      * of the characters to the position of the bars
      *
      * @param  bool $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setStretchText($value)
@@ -684,7 +684,7 @@ abstract class AbstractObject implements ObjectInterface
      * added to the barcode text
      *
      * @param  bool $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setWithChecksum($value)
     {
@@ -711,7 +711,7 @@ abstract class AbstractObject implements ObjectInterface
      * added to the barcode text
      *
      * @param  bool $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setWithChecksumInText($value)
@@ -739,7 +739,7 @@ abstract class AbstractObject implements ObjectInterface
      *  - if string, $value is assumed to be the path to a TTF font
      *
      * @param int|string $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFont($value)
@@ -781,7 +781,7 @@ abstract class AbstractObject implements ObjectInterface
      * Set the size of the font in case of TTF
      *
      * @param float $value
-     * @return AbstractObject Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws \Zend\Barcode\Object\Exception\ExceptionInterface
      */
     public function setFontSize($value)

--- a/src/Object/Code128.php
+++ b/src/Object/Code128.php
@@ -269,7 +269,7 @@ class Code128 extends AbstractObject
     /**
      * Set text to encode
      * @param string $value
-     * @return Code128
+     * @return Code128 Provides a fluent interface
      */
     public function setText($value)
     {

--- a/src/Object/Code128.php
+++ b/src/Object/Code128.php
@@ -269,7 +269,7 @@ class Code128 extends AbstractObject
     /**
      * Set text to encode
      * @param string $value
-     * @return Code128 Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setText($value)
     {

--- a/src/Object/Code25interleaved.php
+++ b/src/Object/Code25interleaved.php
@@ -32,7 +32,7 @@ class Code25interleaved extends Code25
     /**
      * Activate/deactivate drawing of bearer bars
      * @param  bool $value
-     * @return Code25interleaved Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setWithBearerBars($value)
     {

--- a/src/Object/Code25interleaved.php
+++ b/src/Object/Code25interleaved.php
@@ -32,7 +32,7 @@ class Code25interleaved extends Code25
     /**
      * Activate/deactivate drawing of bearer bars
      * @param  bool $value
-     * @return Code25
+     * @return Code25interleaved Provides a fluent interface
      */
     public function setWithBearerBars($value)
     {

--- a/src/Object/Code39.php
+++ b/src/Object/Code39.php
@@ -89,7 +89,7 @@ class Code39 extends AbstractObject
     /**
      * Set text to encode
      * @param string $value
-     * @return Code39 Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setText($value)
     {

--- a/src/Object/Code39.php
+++ b/src/Object/Code39.php
@@ -89,7 +89,7 @@ class Code39 extends AbstractObject
     /**
      * Set text to encode
      * @param string $value
-     * @return Code39
+     * @return Code39 Provides a fluent interface
      */
     public function setText($value)
     {

--- a/src/Object/ObjectInterface.php
+++ b/src/Object/ObjectInterface.php
@@ -23,7 +23,7 @@ interface ObjectInterface
     /**
      * Set barcode state from options array
      * @param  array $options
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setOptions($options);
 
@@ -31,7 +31,7 @@ interface ObjectInterface
      * Set barcode namespace for autoloading
      *
      * @param string $namespace
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setBarcodeNamespace($namespace);
 
@@ -51,7 +51,7 @@ interface ObjectInterface
     /**
      * Set height of the barcode bar
      * @param int $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setBarHeight($value);
 
@@ -64,7 +64,7 @@ interface ObjectInterface
     /**
      * Set thickness of thin bar
      * @param int $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setBarThinWidth($value);
 
@@ -77,7 +77,7 @@ interface ObjectInterface
     /**
      * Set thickness of thick bar
      * @param int $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setBarThickWidth($value);
 
@@ -91,7 +91,7 @@ interface ObjectInterface
      * Set factor applying to
      * thinBarWidth - thickBarWidth - barHeight - fontSize
      * @param int $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setFactor($value);
 
@@ -105,7 +105,7 @@ interface ObjectInterface
     /**
      * Set color of the barcode and text
      * @param string $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setForeColor($value);
 
@@ -118,7 +118,7 @@ interface ObjectInterface
     /**
      * Set the color of the background
      * @param int $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setBackgroundColor($value);
 
@@ -131,7 +131,7 @@ interface ObjectInterface
     /**
      * Activate/deactivate drawing of the bar
      * @param  bool $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setWithBorder($value);
 
@@ -143,14 +143,14 @@ interface ObjectInterface
 
     /**
      * Allow fast inversion of font/bars color and background color
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setReverseColor();
 
     /**
      * Set orientation of barcode and text
      * @param float $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setOrientation($value);
 
@@ -163,7 +163,7 @@ interface ObjectInterface
     /**
      * Set text to encode
      * @param string $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setText($value);
 
@@ -188,7 +188,7 @@ interface ObjectInterface
     /**
      * Activate/deactivate drawing of text to encode
      * @param  bool $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setDrawText($value);
 
@@ -202,7 +202,7 @@ interface ObjectInterface
      * Activate/deactivate the adjustment of the position
      * of the characters to the position of the bars
      * @param  bool $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setStretchText($value);
 
@@ -218,7 +218,7 @@ interface ObjectInterface
      * of the checksum character
      * added to the barcode text
      * @param  bool $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setWithChecksum($value);
 
@@ -234,7 +234,7 @@ interface ObjectInterface
      * of the checksum character
      * added to the barcode text
      * @param  bool $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setWithChecksumInText($value);
 
@@ -250,7 +250,7 @@ interface ObjectInterface
      *  - if integer between 1 and 5, use gd built-in fonts
      *  - if string, $value is assumed to be the path to a TTF font
      * @param int|string $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setFont($value);
 
@@ -263,7 +263,7 @@ interface ObjectInterface
     /**
      * Set the size of the font in case of TTF
      * @param float $value
-     * @return ObjectInterface
+     * @return self Provides a fluent interface
      */
     public function setFontSize($value);
 

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -106,7 +106,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Set renderer state from options array
      * @param  array $options
-     * @return AbstractRenderer
+     * @return AbstractRenderer Provides a fluent interface
      */
     public function setOptions($options)
     {
@@ -123,7 +123,7 @@ abstract class AbstractRenderer implements RendererInterface
      * Set renderer namespace for autoloading
      *
      * @param string $namespace
-     * @return AbstractRenderer
+     * @return AbstractRenderer Provides a fluent interface
      */
     public function setRendererNamespace($namespace)
     {
@@ -146,7 +146,7 @@ abstract class AbstractRenderer implements RendererInterface
      * Will work for SVG and Image (png and gif only)
      *
      * @param $bool
-     * @return $this
+     * @return AbstractRenderer Provides a fluent interface
      */
     public function setTransparentBackground($bool)
     {
@@ -175,7 +175,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Manually adjust top position
      * @param  int $value
-     * @return AbstractRenderer
+     * @return AbstractRenderer Provides a fluent interface
      * @throws Exception\OutOfRangeException
      */
     public function setTopOffset($value)
@@ -201,7 +201,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Manually adjust left position
      * @param  int $value
-     * @return AbstractRenderer
+     * @return AbstractRenderer Provides a fluent interface
      * @throws Exception\OutOfRangeException
      */
     public function setLeftOffset($value)
@@ -227,7 +227,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Activate/Deactivate the automatic rendering of exception
      * @param  bool $value
-     * @return AbstractRenderer
+     * @return AbstractRenderer Provides a fluent interface
      */
     public function setAutomaticRenderError($value)
     {
@@ -238,7 +238,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Horizontal position of the barcode in the rendering resource
      * @param  string $value
-     * @return AbstractRenderer
+     * @return AbstractRenderer Provides a fluent interface
      * @throws Exception\UnexpectedValueException
      */
     public function setHorizontalPosition($value)
@@ -264,7 +264,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Vertical position of the barcode in the rendering resource
      * @param  string $value
-     * @return AbstractRenderer
+     * @return AbstractRenderer Provides a fluent interface
      * @throws Exception\UnexpectedValueException
      */
     public function setVerticalPosition($value)
@@ -290,7 +290,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Set the size of a module
      * @param float $value
-     * @return AbstractRenderer
+     * @return AbstractRenderer Provides a fluent interface
      * @throws Exception\OutOfRangeException
      */
     public function setModuleSize($value)
@@ -325,7 +325,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Set the barcode object
      * @param  Object\ObjectInterface $barcode
-     * @return AbstractRenderer
+     * @return AbstractRenderer Provides a fluent interface
      */
     public function setBarcode(Object\ObjectInterface $barcode)
     {

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -106,7 +106,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Set renderer state from options array
      * @param  array $options
-     * @return AbstractRenderer Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setOptions($options)
     {
@@ -123,7 +123,7 @@ abstract class AbstractRenderer implements RendererInterface
      * Set renderer namespace for autoloading
      *
      * @param string $namespace
-     * @return AbstractRenderer Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setRendererNamespace($namespace)
     {
@@ -146,7 +146,7 @@ abstract class AbstractRenderer implements RendererInterface
      * Will work for SVG and Image (png and gif only)
      *
      * @param $bool
-     * @return AbstractRenderer Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setTransparentBackground($bool)
     {
@@ -175,7 +175,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Manually adjust top position
      * @param  int $value
-     * @return AbstractRenderer Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\OutOfRangeException
      */
     public function setTopOffset($value)
@@ -201,7 +201,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Manually adjust left position
      * @param  int $value
-     * @return AbstractRenderer Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\OutOfRangeException
      */
     public function setLeftOffset($value)
@@ -227,7 +227,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Activate/Deactivate the automatic rendering of exception
      * @param  bool $value
-     * @return AbstractRenderer Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setAutomaticRenderError($value)
     {
@@ -238,7 +238,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Horizontal position of the barcode in the rendering resource
      * @param  string $value
-     * @return AbstractRenderer Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\UnexpectedValueException
      */
     public function setHorizontalPosition($value)
@@ -264,7 +264,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Vertical position of the barcode in the rendering resource
      * @param  string $value
-     * @return AbstractRenderer Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\UnexpectedValueException
      */
     public function setVerticalPosition($value)
@@ -290,7 +290,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Set the size of a module
      * @param float $value
-     * @return AbstractRenderer Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\OutOfRangeException
      */
     public function setModuleSize($value)
@@ -325,7 +325,7 @@ abstract class AbstractRenderer implements RendererInterface
     /**
      * Set the barcode object
      * @param  Object\ObjectInterface $barcode
-     * @return AbstractRenderer Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setBarcode(Object\ObjectInterface $barcode)
     {

--- a/src/Renderer/Image.php
+++ b/src/Renderer/Image.php
@@ -83,7 +83,7 @@ class Image extends AbstractRenderer
      *
      * @param null|int $value
      * @throws Exception\OutOfRangeException
-     * @return Image Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setHeight($value)
     {
@@ -111,7 +111,7 @@ class Image extends AbstractRenderer
      *
      * @param mixed $value
      * @throws Exception\OutOfRangeException
-     * @return Image Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setWidth($value)
     {
@@ -138,7 +138,7 @@ class Image extends AbstractRenderer
      * Set an image resource to draw the barcode inside
      *
      * @param resource $image
-     * @return Image Provides a fluent interface
+     * @return self Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setResource($image)
@@ -157,7 +157,7 @@ class Image extends AbstractRenderer
      *
      * @param string $value
      * @throws Exception\InvalidArgumentException
-     * @return Image Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setImageType($value)
     {

--- a/src/Renderer/Image.php
+++ b/src/Renderer/Image.php
@@ -83,7 +83,7 @@ class Image extends AbstractRenderer
      *
      * @param null|int $value
      * @throws Exception\OutOfRangeException
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setHeight($value)
     {
@@ -111,7 +111,7 @@ class Image extends AbstractRenderer
      *
      * @param mixed $value
      * @throws Exception\OutOfRangeException
-     * @return self
+     * @return Image Provides a fluent interface
      */
     public function setWidth($value)
     {
@@ -138,7 +138,7 @@ class Image extends AbstractRenderer
      * Set an image resource to draw the barcode inside
      *
      * @param resource $image
-     * @return Image
+     * @return Image Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setResource($image)
@@ -157,7 +157,7 @@ class Image extends AbstractRenderer
      *
      * @param string $value
      * @throws Exception\InvalidArgumentException
-     * @return Image
+     * @return Image Provides a fluent interface
      */
     public function setImageType($value)
     {

--- a/src/Renderer/Pdf.php
+++ b/src/Renderer/Pdf.php
@@ -42,7 +42,7 @@ class Pdf extends AbstractRenderer
      *
      * @param PdfDocument $pdf
      * @param int $page
-     * @return Pdf Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setResource(PdfDocument $pdf, $page = 0)
     {

--- a/src/Renderer/Pdf.php
+++ b/src/Renderer/Pdf.php
@@ -41,8 +41,8 @@ class Pdf extends AbstractRenderer
      * Set a PDF resource to draw the barcode inside
      *
      * @param PdfDocument $pdf
-     * @param int     $page
-     * @return Pdf
+     * @param int $page
+     * @return Pdf Provides a fluent interface
      */
     public function setResource(PdfDocument $pdf, $page = 0)
     {

--- a/src/Renderer/RendererInterface.php
+++ b/src/Renderer/RendererInterface.php
@@ -25,7 +25,7 @@ interface RendererInterface
     /**
      * Set renderer state from options array
      * @param  array $options
-     * @return RendererInterface
+     * @return self Provides a fluent interface
      */
     public function setOptions($options);
 
@@ -33,7 +33,7 @@ interface RendererInterface
      * Set renderer namespace for autoloading
      *
      * @param string $namespace
-     * @return RendererInterface
+     * @return self Provides a fluent interface
      */
     public function setRendererNamespace($namespace);
 
@@ -53,7 +53,7 @@ interface RendererInterface
     /**
      * Manually adjust top position
      * @param int $value
-     * @return RendererInterface
+     * @return self Provides a fluent interface
      */
     public function setTopOffset($value);
 
@@ -66,7 +66,7 @@ interface RendererInterface
     /**
      * Manually adjust left position
      * @param int $value
-     * @return RendererInterface
+     * @return self Provides a fluent interface
      */
     public function setLeftOffset($value);
 
@@ -86,7 +86,7 @@ interface RendererInterface
     /**
      * Horizontal position of the barcode in the rendering resource
      * @param string $value
-     * @return RendererInterface
+     * @return self Provides a fluent interface
      */
     public function setHorizontalPosition($value);
 
@@ -99,7 +99,7 @@ interface RendererInterface
     /**
      * Vertical position of the barcode in the rendering resource
      * @param string $value
-     * @return RendererInterface
+     * @return self Provides a fluent interface
      */
     public function setVerticalPosition($value);
 
@@ -112,7 +112,7 @@ interface RendererInterface
     /**
      * Set the size of a module
      * @param float $value
-     * @return RendererInterface
+     * @return self Provides a fluent interface
      */
     public function setModuleSize($value);
 
@@ -131,7 +131,7 @@ interface RendererInterface
     /**
      * Set the barcode object
      * @param  ObjectInterface $barcode
-     * @return RendererInterface
+     * @return self Provides a fluent interface
      */
     public function setBarcode(ObjectInterface $barcode);
 

--- a/src/Renderer/Svg.php
+++ b/src/Renderer/Svg.php
@@ -52,7 +52,7 @@ class Svg extends AbstractRenderer
      * Set height of the result image
      * @param null|int $value
      * @throws Exception\OutOfRangeException
-     * @return Svg
+     * @return Svg Provides a fluent interface
      */
     public function setHeight($value)
     {
@@ -80,7 +80,7 @@ class Svg extends AbstractRenderer
      *
      * @param mixed $value
      * @throws Exception\OutOfRangeException
-     * @return self
+     * @return Svg Provides a fluent interface
      */
     public function setWidth($value)
     {
@@ -107,7 +107,7 @@ class Svg extends AbstractRenderer
      * Set an image resource to draw the barcode inside
      *
      * @param  DOMDocument $svg
-     * @return Svg
+     * @return Svg Provides a fluent interface
      */
     public function setResource(DOMDocument $svg)
     {

--- a/src/Renderer/Svg.php
+++ b/src/Renderer/Svg.php
@@ -52,7 +52,7 @@ class Svg extends AbstractRenderer
      * Set height of the result image
      * @param null|int $value
      * @throws Exception\OutOfRangeException
-     * @return Svg Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setHeight($value)
     {
@@ -80,7 +80,7 @@ class Svg extends AbstractRenderer
      *
      * @param mixed $value
      * @throws Exception\OutOfRangeException
-     * @return Svg Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setWidth($value)
     {
@@ -107,7 +107,7 @@ class Svg extends AbstractRenderer
      * Set an image resource to draw the barcode inside
      *
      * @param  DOMDocument $svg
-     * @return Svg Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setResource(DOMDocument $svg)
     {


### PR DESCRIPTION
As discussed in [fluent interface return type vs return self #7193](https://github.com/zendframework/zendframework/issues/7193), this changes remove occurrences of class names and self keyword from the DocBlocks
