### PR TITLE
typo fixed

### DIFF
--- a/doc/book/intro.md
+++ b/doc/book/intro.md
@@ -3,4 +3,4 @@
 `Zend\Barcode\Barcode` provides a generic way to generate barcodes. The
 `Zend\Barcode` component is divided into two subcomponents: barcode objects and
 renderers. *Objects* allow you to create barcodes independently of the renderer.
-*Renderers* allow you to draw barcodes based on the target outpu.
+*Renderers* allow you to draw barcodes based on the target output.


### PR DESCRIPTION
A minor fix - there was a typo in the documentation - 'outpu'