### PR TITLE
Fix typo in exception message

### DIFF
--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -467,7 +467,7 @@ abstract class AbstractRenderer implements RendererInterface
                     break;
                 default:
                     throw new Exception\UnexpectedValueException(
-                        'Unkown drawing command'
+                        'Unknown drawing command'
                     );
             }
         }


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

Hopefully a safe fix for a typo in an exception