### PR TITLE
Fix: replace curly offset access brace with square brackets

### DIFF
--- a/src/Object/AbstractObject.php
+++ b/src/Object/AbstractObject.php
@@ -1218,7 +1218,7 @@ abstract class AbstractObject implements ObjectInterface
                 for ($i = 0; $i < $textLength; $i ++) {
                     $leftPosition = $this->getQuietZone() + $space * ($i + 0.5);
                     $this->addText(
-                        $text{$i},
+                        $text[$i],
                         $this->fontSize * $this->factor,
                         $this->rotate(
                             $leftPosition,

--- a/src/Object/Code25.php
+++ b/src/Object/Code25.php
@@ -106,7 +106,7 @@ class Code25 extends AbstractObject
         $checksum = 0;
 
         for ($i = strlen($text); $i > 0; $i --) {
-            $checksum += intval($text{$i - 1}) * $factor;
+            $checksum += intval($text[$i - 1]) * $factor;
             $factor    = 4 - $factor;
         }
 

--- a/src/Object/Ean13.php
+++ b/src/Object/Ean13.php
@@ -140,7 +140,7 @@ class Ean13 extends AbstractObject
         $checksum = 0;
 
         for ($i = strlen($text); $i > 0; $i --) {
-            $checksum += intval($text{$i - 1}) * $factor;
+            $checksum += intval($text[$i - 1]) * $factor;
             $factor    = 4 - $factor;
         }
 
@@ -170,7 +170,7 @@ class Ean13 extends AbstractObject
             $leftPosition = $this->getQuietZone() - $characterWidth;
             for ($i = 0; $i < $this->barcodeLength; $i ++) {
                 $this->addText(
-                    $text{$i},
+                    $text[$i],
                     $this->fontSize * $this->factor,
                     $this->rotate(
                         $leftPosition,

--- a/src/Object/Ean5.php
+++ b/src/Object/Ean5.php
@@ -103,7 +103,7 @@ class Ean5 extends Ean13
         $checksum = 0;
 
         for ($i = 0; $i < $this->barcodeLength; $i ++) {
-            $checksum += intval($text{$i}) * ($i % 2 ? 9 : 3);
+            $checksum += intval($text[$i]) * ($i % 2 ? 9 : 3);
         }
 
         return ($checksum % 10);

--- a/src/Object/Ean8.php
+++ b/src/Object/Ean8.php
@@ -98,7 +98,7 @@ class Ean8 extends Ean13
             $leftPosition = $this->getQuietZone() + (3 * $this->barThinWidth) * $this->factor;
             for ($i = 0; $i < $this->barcodeLength; $i ++) {
                 $this->addText(
-                    $text{$i},
+                    $text[$i],
                     $this->fontSize * $this->factor,
                     $this->rotate(
                         $leftPosition,

--- a/src/Object/Identcode.php
+++ b/src/Object/Identcode.php
@@ -56,7 +56,7 @@ class Identcode extends Code25interleaved
         $checksum = 0;
 
         for ($i = strlen($text); $i > 0; $i --) {
-            $checksum += intval($text{$i - 1}) * (($i % 2) ? 4 : 9);
+            $checksum += intval($text[$i - 1]) * (($i % 2) ? 4 : 9);
         }
 
         $checksum = (10 - ($checksum % 10)) % 10;

--- a/src/Object/Upca.php
+++ b/src/Object/Upca.php
@@ -113,7 +113,7 @@ class Upca extends Ean13
                     $fontSize *= 0.8;
                 }
                 $this->addText(
-                    $text{$i},
+                    $text[$i],
                     $fontSize * $this->factor,
                     $this->rotate(
                         $leftPosition,

--- a/src/Object/Upce.php
+++ b/src/Object/Upce.php
@@ -133,7 +133,7 @@ class Upce extends Ean13
                     $fontSize *= 0.8;
                 }
                 $this->addText(
-                    $text{$i},
+                    $text[$i],
                     $fontSize * $this->factor,
                     $this->rotate(
                         $leftPosition,


### PR DESCRIPTION
As of PHP 7.4:
the array and string offset access syntax using curly braces is deprecated.

- [x] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->
