### PR TITLE
Hotfix: generating checksum for Ean5 and Identcode/Leitcode

### DIFF
--- a/src/Object/Ean5.php
+++ b/src/Object/Ean5.php
@@ -100,10 +100,12 @@ class Ean5 extends Ean13
     public function getChecksum($text)
     {
         $this->checkText($text);
+        $text = $this->addLeadingZeros($text, true);
+
         $checksum = 0;
 
         for ($i = 0; $i < $this->barcodeLength; $i ++) {
-            $checksum += intval($text[$i]) * ($i % 2 ? 9 : 3);
+            $checksum += (int) $text[$i] * (($i % 2) ? 9 : 3);
         }
 
         return ($checksum % 10);

--- a/src/Object/Identcode.php
+++ b/src/Object/Identcode.php
@@ -53,10 +53,12 @@ class Identcode extends Code25interleaved
     public function getChecksum($text)
     {
         $this->checkText($text);
+        $text = $this->addLeadingZeros($text, true);
+
         $checksum = 0;
 
         for ($i = strlen($text); $i > 0; $i --) {
-            $checksum += intval($text[$i - 1]) * (($i % 2) ? 4 : 9);
+            $checksum += (int) $text[$i - 1] * (($i % 2) ? 4 : 9);
         }
 
         $checksum = (10 - ($checksum % 10)) % 10;

--- a/test/Object/Ean5Test.php
+++ b/test/Object/Ean5Test.php
@@ -26,9 +26,21 @@ class Ean5Test extends TestCommon
         $this->assertSame('ean5', $this->object->getType());
     }
 
-    public function testChecksum()
+    public function checksum()
     {
-        $this->assertSame(2, $this->object->getChecksum('45678'));
+        yield ['45678', 2];
+        yield ['5678', 0];
+        yield ['05678', 0];
+    }
+
+    /**
+     * @dataProvider checksum
+     * @var string $text
+     * @var int $checksum
+     */
+    public function testChecksum($text, $checksum)
+    {
+        $this->assertSame($checksum, $this->object->getChecksum($text));
     }
 
     public function testSetText()

--- a/test/Object/IdentcodeTest.php
+++ b/test/Object/IdentcodeTest.php
@@ -26,9 +26,25 @@ class IdentcodeTest extends TestCommon
         $this->assertSame('identcode', $this->object->getType());
     }
 
-    public function testChecksum()
+    public function checksum()
     {
-        $this->assertSame(6, $this->object->getChecksum('12345678901'));
+        yield ['12345678901', 6];
+        yield ['709003', 4];
+        yield ['0709003', 4];
+        yield ['00709003', 4];
+        yield ['000709003', 4];
+        yield ['0000709003', 4];
+        yield ['00000709003', 4];
+    }
+
+    /**
+     * @dataProvider checksum
+     * @param string $text
+     * @param int $checksum
+     */
+    public function testChecksum($text, $checksum)
+    {
+        $this->assertSame($checksum, $this->object->getChecksum($text));
     }
 
     public function testSetText()

--- a/test/Object/LeitcodeTest.php
+++ b/test/Object/LeitcodeTest.php
@@ -26,9 +26,28 @@ class LeitcodeTest extends TestCommon
         $this->assertSame('leitcode', $this->object->getType());
     }
 
-    public function testChecksum()
+    public function checksum()
     {
-        $this->assertSame(8, $this->object->getChecksum('0123456789012'));
+        yield ['0123456789012', 8];
+        yield ['123456789012', 8];
+        yield ['709003', 4];
+        yield ['0709003', 4];
+        yield ['00709003', 4];
+        yield ['000709003', 4];
+        yield ['0000709003', 4];
+        yield ['00000709003', 4];
+        yield ['000000709003', 4];
+        yield ['0000000709003', 4];
+    }
+
+    /**
+     * @dataProvider checksum
+     * @param string $text
+     * @param int $checksum
+     */
+    public function testChecksum($text, $checksum)
+    {
+        $this->assertSame($checksum, $this->object->getChecksum($text));
     }
 
     public function testSetText()


### PR DESCRIPTION
These barcodes have fixed length, when providing shorter text leading 0
are added to keep the same length. Checksum should be calculated from
the full text, with leading 0, so the result with and without leading 0
should be exactly the same.

In general validator shouldn't pass on shorter text than expected, but
AbstractObject before passing value to validator is adding leading 0.
That's why validation is fine, but checksum in some cases is not.

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.
