### PR TITLE
Hotfix: leading zeros for EAN2 and EAN5 "with checksum"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ All notable changes to this project will be documented in this file, in reverse 
   curly braces in array and string offset access to square brackets
   in order to prevent issues under the upcoming PHP 7.4 release.
 
+- [#47](https://github.com/zendframework/zend-barcode/pull/47) fixes
+  text length for EAN2 and EAN5 by adding leading zeros.
+
 ## 2.7.0 - 2017-12-11
 
 ### Added

--- a/src/Object/Ean5.php
+++ b/src/Object/Ean5.php
@@ -127,4 +127,12 @@ class Ean5 extends Ean13
     {
         return $this->addLeadingZeros($this->text);
     }
+
+    /**
+     * @return string
+     */
+    public function getTextToDisplay()
+    {
+        return $this->getText();
+    }
 }

--- a/test/Object/Ean2Test.php
+++ b/test/Object/Ean2Test.php
@@ -136,4 +136,24 @@ class Ean2Test extends TestCommon
         $this->object->setText('43');
         $this->assertEquals(62, $this->object->getHeight(true));
     }
+
+    public function testTextToDisplayWithChecksum()
+    {
+        $this->object->setText('1');
+        $this->object->setWithChecksum(true);
+
+        $this->assertSame('1', $this->object->getRawText());
+        $this->assertSame('01', $this->object->getText());
+        $this->assertSame('01', $this->object->getTextToDisplay());
+    }
+
+    public function testTextToDisplayWithoutChecksum()
+    {
+        $this->object->setText('1');
+        $this->object->setWithChecksum(false);
+
+        $this->assertSame('1', $this->object->getRawText());
+        $this->assertSame('01', $this->object->getText());
+        $this->assertSame('01', $this->object->getTextToDisplay());
+    }
 }

--- a/test/Object/Ean5Test.php
+++ b/test/Object/Ean5Test.php
@@ -136,4 +136,24 @@ class Ean5Test extends TestCommon
         $this->object->setText('45678');
         $this->assertEquals(62, $this->object->getHeight(true));
     }
+
+    public function testTextToDisplayWithChecksum()
+    {
+        $this->object->setText('123');
+        $this->object->setWithChecksum(true);
+
+        $this->assertSame('123', $this->object->getRawText());
+        $this->assertSame('00123', $this->object->getText());
+        $this->assertSame('00123', $this->object->getTextToDisplay());
+    }
+
+    public function testTextToDisplayWithoutChecksum()
+    {
+        $this->object->setText('123');
+        $this->object->setWithChecksum(false);
+
+        $this->assertSame('123', $this->object->getRawText());
+        $this->assertSame('00123', $this->object->getText());
+        $this->assertSame('00123', $this->object->getTextToDisplay());
+    }
 }


### PR DESCRIPTION
Checksum for EAN2 and EAN5 is "used internally" (per documentation) and
not displayed. Also per documentation leading 0 should be added if the
text length is shorter than expected.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.
