### PR TITLE
Feature: Ability to provide barcode with checksum

### DIFF
--- a/docs/book/objects.md
+++ b/docs/book/objects.md
@@ -63,7 +63,33 @@ Option               | Data Type                   | Default Value         | Des
 `stretchText`        | bool                        | `FALSE`               | Specify if the text is stretched all along the barcode.
 `withChecksum`       | bool                        | `FALSE`               | Indicate whether or not the checksum is automatically added to the barcode.
 `withChecksumInText` | bool                        | `FALSE`               | Indicate whether or not the checksum is displayed in the textual representation.
+`providedChecksum`   | bool                        | `FALSE`               | Indicate whether or not the checksum is provided with the barcode text. (Available since 2.8.0)
 `text`               | string                      | `NULL`                | The text to represent as a barcode.
+
+### Text with checksum
+
+> Available since 2.8.0
+
+With barcodes where checksum is mandatory
+(*EAN* 8, *EAN* 13, *ITF* 14, Leitcode, Identcode, *UPC*-A, *UPC*-E, Postnet, Royalmail)
+you can provide text with checksum:
+
+```php
+$barcode = new Ean13([
+    'text' => '1234567890128',
+    'providedChecksum' => true,
+]);
+```
+
+where `8` is checksum. Without checksum it will be:
+
+```php
+$barcode = new Ean13([
+    'text' => '123456789012',
+]);
+```
+
+and the final result of the rendered barcode is the same.
 
 ### Setting a common font for all objects
 

--- a/src/Object/AbstractObject.php
+++ b/src/Object/AbstractObject.php
@@ -193,6 +193,13 @@ abstract class AbstractObject implements ObjectInterface
     protected $withChecksumInText = false;
 
     /**
+     * Whether checksum is provided with the input text or not.
+     *
+     * @var bool
+     */
+    protected $providedChecksum = false;
+
+    /**
      * Fix barcode length (numeric or string like 'even')
      *
      * @var int | string
@@ -576,7 +583,7 @@ abstract class AbstractObject implements ObjectInterface
     public function getText()
     {
         $text = $this->text;
-        if ($this->withChecksum) {
+        if ($this->withChecksum && ! $this->providedChecksum) {
             $text .= $this->getChecksum($this->text);
         }
         return $this->addLeadingZeros($text);
@@ -624,6 +631,8 @@ abstract class AbstractObject implements ObjectInterface
      */
     public function getTextToDisplay()
     {
+        $this->checkText($this->text);
+
         if ($this->withChecksumInText) {
             return $this->getText();
         }
@@ -731,6 +740,25 @@ abstract class AbstractObject implements ObjectInterface
     public function getWithChecksumInText()
     {
         return $this->withChecksumInText;
+    }
+
+    /**
+     * @param bool $value
+     * @return $this
+     */
+    public function setProvidedChecksum($value)
+    {
+        $this->providedChecksum = (bool) $value;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getProvidedChecksum()
+    {
+        return $this->providedChecksum;
     }
 
     /**
@@ -1269,12 +1297,12 @@ abstract class AbstractObject implements ObjectInterface
 
         $validator = new BarcodeValidator([
             'adapter'  => $validatorName,
-            'usechecksum' => false,
+            'usechecksum' => $this->providedChecksum,
         ]);
 
         $checksumCharacter = '';
         $withChecksum = false;
-        if ($this->mandatoryChecksum) {
+        if ($this->mandatoryChecksum && ! $this->providedChecksum) {
             $checksumCharacter = $this->substituteChecksumCharacter;
             $withChecksum = true;
         }

--- a/src/Object/Identcode.php
+++ b/src/Object/Identcode.php
@@ -30,6 +30,8 @@ class Identcode extends Code25interleaved
      */
     public function getTextToDisplay()
     {
+        $this->checkText($this->text);
+
         return preg_replace('/([0-9]{2})([0-9]{3})([0-9]{3})([0-9]{3})([0-9])/', '$1.$2 $3.$4 $5', $this->getText());
     }
 

--- a/src/Object/Leitcode.php
+++ b/src/Object/Leitcode.php
@@ -30,6 +30,8 @@ class Leitcode extends Identcode
      */
     public function getTextToDisplay()
     {
+        $this->checkText($this->text);
+
         return preg_replace('/([0-9]{5})([0-9]{3})([0-9]{3})([0-9]{2})([0-9])/', '$1.$2.$3.$4 $5', $this->getText());
     }
 }

--- a/test/Object/Ean13Test.php
+++ b/test/Object/Ean13Test.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Barcode\Object;
 
 use Zend\Barcode;
+use Zend\Barcode\Object\Exception\BarcodeValidationException;
 
 /**
  * @group      Zend_Barcode
@@ -143,5 +144,28 @@ class Ean13Test extends TestCommon
         // Checksum activated => text needed
         $this->object->setText('000123456789');
         $this->assertEquals(62, $this->object->getHeight(true));
+    }
+
+    public function testChecksumIsNotProvided()
+    {
+        $this->object->setText('123456789012');
+        self::assertSame('1234567890128', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksum()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('1234567890128');
+        self::assertSame('1234567890128', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksumInvalid()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('1234567890123');
+
+        $this->expectException(BarcodeValidationException::class);
+        $this->expectExceptionMessage('The input failed checksum validation');
+        $this->object->getTextToDisplay();
     }
 }

--- a/test/Object/Ean8Test.php
+++ b/test/Object/Ean8Test.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Barcode\Object;
 
 use Zend\Barcode\Object\Ean8;
+use Zend\Barcode\Object\Exception\BarcodeValidationException;
 
 /**
  * @group      Zend_Barcode
@@ -142,5 +143,28 @@ class Ean8Test extends TestCommon
         // Checksum activated => text needed
         $this->object->setText('123456');
         $this->assertEquals(62, $this->object->getHeight(true));
+    }
+
+    public function testChecksumIsNotProvided()
+    {
+        $this->object->setText('1234567');
+        self::assertSame('12345670', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksum()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('12345670');
+        self::assertSame('12345670', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksumInvalid()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('12345678');
+
+        $this->expectException(BarcodeValidationException::class);
+        $this->expectExceptionMessage('The input failed checksum validation');
+        $this->object->getTextToDisplay();
     }
 }

--- a/test/Object/IdentcodeTest.php
+++ b/test/Object/IdentcodeTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Barcode\Object;
 
 use Zend\Barcode;
+use Zend\Barcode\Object\Exception\BarcodeValidationException;
 
 /**
  * @group      Zend_Barcode
@@ -143,5 +144,28 @@ class IdentcodeTest extends TestCommon
         // Checksum activated => text needed
         $this->object->setText('00123456789');
         $this->assertEquals(62, $this->object->getHeight(true));
+    }
+
+    public function testChecksumIsNotProvided()
+    {
+        $this->object->setText('12345678901');
+        self::assertSame('12.345 678.901 6', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksum()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('123456789016');
+        self::assertSame('12.345 678.901 6', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksumInvalid()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('123456789012');
+
+        $this->expectException(BarcodeValidationException::class);
+        $this->expectExceptionMessage('The input failed checksum validation');
+        $this->object->getTextToDisplay();
     }
 }

--- a/test/Object/Itf14Test.php
+++ b/test/Object/Itf14Test.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Barcode\Object;
 
 use Zend\Barcode;
+use Zend\Barcode\Object\Exception\BarcodeValidationException;
 
 /**
  * @group      Zend_Barcode
@@ -206,5 +207,28 @@ class Itf14Test extends TestCommon
         // Checksum activated => text needed
         $this->object->setText('0000123456789');
         $this->assertEquals(62, $this->object->getHeight(true));
+    }
+
+    public function testChecksumIsNotProvided()
+    {
+        $this->object->setText('1234567890123');
+        self::assertSame('12345678901231', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksum()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('12345678901231');
+        self::assertSame('12345678901231', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksumInvalid()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('12345678901234');
+
+        $this->expectException(BarcodeValidationException::class);
+        $this->expectExceptionMessage('The input failed checksum validation');
+        $this->object->getTextToDisplay();
     }
 }

--- a/test/Object/LeitcodeTest.php
+++ b/test/Object/LeitcodeTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Barcode\Object;
 
 use Zend\Barcode;
+use Zend\Barcode\Object\Exception\BarcodeValidationException;
 
 /**
  * @group      Zend_Barcode
@@ -143,5 +144,28 @@ class LeitcodeTest extends TestCommon
         // Checksum activated => text needed
         $this->object->setText('0000123456789');
         $this->assertEquals(62, $this->object->getHeight(true));
+    }
+
+    public function testChecksumIsNotProvided()
+    {
+        $this->object->setText('1234567890123');
+        self::assertSame('12345.678.901.23 6', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksum()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('12345678901236');
+        self::assertSame('12345.678.901.23 6', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksumInvalid()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('12345678901234');
+
+        $this->expectException(BarcodeValidationException::class);
+        $this->expectExceptionMessage('The input failed checksum validation');
+        $this->object->getTextToDisplay();
     }
 }

--- a/test/Object/PostnetTest.php
+++ b/test/Object/PostnetTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Barcode\Object;
 
 use Zend\Barcode;
+use Zend\Barcode\Object\Exception\BarcodeValidationException;
 
 /**
  * @group      Zend_Barcode
@@ -143,5 +144,28 @@ class PostnetTest extends TestCommon
         // Checksum activated => text needed
         $this->object->setText('012345');
         $this->assertEquals(20, $this->object->getHeight(true));
+    }
+
+    public function testChecksumIsNotProvided()
+    {
+        $this->object->setText('123456');
+        self::assertSame('1234569', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksum()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('1234569');
+        self::assertSame('1234569', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksumInvalid()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('1234567');
+
+        $this->expectException(BarcodeValidationException::class);
+        $this->expectExceptionMessage('The input failed checksum validation');
+        $this->object->getTextToDisplay();
     }
 }

--- a/test/Object/RoyalmailTest.php
+++ b/test/Object/RoyalmailTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Barcode\Object;
 
 use Zend\Barcode;
+use Zend\Barcode\Object\Exception\BarcodeValidationException;
 
 /**
  * @group      Zend_Barcode
@@ -136,5 +137,28 @@ class RoyalmailTest extends TestCommon
         // Checksum activated => text needed
         $this->object->setText('012345');
         $this->assertEquals(20, $this->object->getHeight(true));
+    }
+
+    public function testChecksumIsNotProvided()
+    {
+        $this->object->setText('123456');
+        self::assertSame('1234562', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksum()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('1234562');
+        self::assertSame('1234562', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksumInvalid()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('1234567');
+
+        $this->expectException(BarcodeValidationException::class);
+        $this->expectExceptionMessage('The input failed checksum validation');
+        $this->object->getTextToDisplay();
     }
 }

--- a/test/Object/TestCommon.php
+++ b/test/Object/TestCommon.php
@@ -260,6 +260,19 @@ abstract class TestCommon extends TestCase
         $this->assertSame(true, $this->object->getWithChecksumInText());
     }
 
+    public function testProvidedChecksumFalseByDefault()
+    {
+        self::assertFalse($this->object->getProvidedChecksum());
+    }
+
+    public function testProvidedChecksum()
+    {
+        $this->object->setProvidedChecksum(1);
+        self::assertTrue($this->object->getProvidedChecksum());
+        $this->object->setProvidedChecksum(true);
+        self::assertTrue($this->object->getProvidedChecksum());
+    }
+
     public function testWithoutQuietZones()
     {
         $this->object->setWithQuietZones(0);

--- a/test/Object/UpcaTest.php
+++ b/test/Object/UpcaTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Barcode\Object;
 
 use Zend\Barcode;
+use Zend\Barcode\Object\Exception\BarcodeValidationException;
 
 /**
  * @group      Zend_Barcode
@@ -143,5 +144,28 @@ class UpcaTest extends TestCommon
         // Checksum activated => text needed
         $this->object->setText('00123456789');
         $this->assertEquals(62, $this->object->getHeight(true));
+    }
+
+    public function testChecksumIsNotProvided()
+    {
+        $this->object->setText('12345678901');
+        self::assertSame('123456789012', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksum()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('123456789012');
+        self::assertSame('123456789012', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksumInvalid()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('123456789013');
+
+        $this->expectException(BarcodeValidationException::class);
+        $this->expectExceptionMessage('The input failed checksum validation');
+        $this->object->getTextToDisplay();
     }
 }

--- a/test/Object/UpceTest.php
+++ b/test/Object/UpceTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Barcode\Object;
 
 use Zend\Barcode;
+use Zend\Barcode\Object\Exception\BarcodeValidationException;
 
 /**
  * @group      Zend_Barcode
@@ -150,5 +151,28 @@ class UpceTest extends TestCommon
         // Checksum activated => text needed
         $this->object->setText('1234567');
         $this->assertEquals(62, $this->object->getHeight(true));
+    }
+
+    public function testChecksumIsNotProvided()
+    {
+        $this->object->setText('1234567');
+        self::assertSame('12345670', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksum()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('12345670');
+        self::assertSame('12345670', $this->object->getTextToDisplay());
+    }
+
+    public function testProvidedChecksumInvalid()
+    {
+        $this->object->setProvidedChecksum(true);
+        $this->object->setText('12345678');
+
+        $this->expectException(BarcodeValidationException::class);
+        $this->expectExceptionMessage('The input failed checksum validation');
+        $this->object->getTextToDisplay();
     }
 }


### PR DESCRIPTION
Added new option "providedChecksum" to indicate if the checksum has been
provided with the barcode text.

Resolves #13

We have now three "similar" options:
- `withChecksum` - whether or not the checksum is automatically added to the barcode
- `withChecksumInText` - whether or not the checksum is displayed in the textual representation
- `providedChecksum` - whether or not the checksum is provided with the barcode text

so the new option is about the input barcode text. 
If it's provided validator checks if the provided checksum is valid.

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
  - [x] How will users use the new feature?
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [x] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.
